### PR TITLE
Rename ConnectableFlow to FlowTap.

### DIFF
--- a/src/commonMain/kotlin/com/zachklipp/flowops/FlowTap.kt
+++ b/src/commonMain/kotlin/com/zachklipp/flowops/FlowTap.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
  * A [Flow] that won't collect the upstream flow until it is explicitly [connected][connectAndJoin].
  */
 @FlowPreview
-interface ConnectableFlow<out T> : Flow<T> {
+interface FlowTap<out T> : Flow<T> {
 
     /**
      * Connects to the upstream [Flow] and suspends until it completes.
@@ -27,6 +27,6 @@ interface ConnectableFlow<out T> : Flow<T> {
      * @see connectAndJoin
      */
     fun connectIn(scope: CoroutineScope): Job = scope.launch {
-        this@ConnectableFlow.connectAndJoin()
+        this@FlowTap.connectAndJoin()
     }
 }

--- a/src/commonMain/kotlin/com/zachklipp/flowops/Publish.kt
+++ b/src/commonMain/kotlin/com/zachklipp/flowops/Publish.kt
@@ -16,11 +16,11 @@ import kotlinx.coroutines.withContext
 /**
  * Broadcasts this [Flow].
  *
- * The returned [Flow] is a [ConnectableFlow], which means it won't collect from
- * the upstream [Flow] until it is [connected][ConnectableFlow.connectIn]. After being connected, it will
+ * The returned [Flow] is a [FlowTap], which means it won't collect from
+ * the upstream [Flow] until it is [connected][FlowTap.connectIn]. After being connected, it will
  * collect only once from the upstream [Flow] for every downstream collector. Every element emitted by
  * the upstream [Flow] will be emitted to each downstream [Flow]. This is similar to [BroadcastChannel], but
- * won't start broadcasting until it is explicitly connected. The returned [ConnectableFlow] can also be
+ * won't start broadcasting until it is explicitly connected. The returned [FlowTap] can also be
  * disconnected by cancelling the connector coroutine, which will stop collecting from upstream. Disconnecting
  * will not cause downstream [Flow]s to complete.
  *
@@ -32,14 +32,14 @@ import kotlinx.coroutines.withContext
  * @see replayMostRecent
  */
 @FlowPreview
-fun <T> Flow<T>.publish(downstreamBufferSize: Int = 16): ConnectableFlow<T> =
-    PublishConnectableFlow(this, downstreamBufferSize)
+fun <T> Flow<T>.publish(downstreamBufferSize: Int = 16): FlowTap<T> =
+    PublishFlowTap(this, downstreamBufferSize)
 
 @FlowPreview
-internal open class PublishConnectableFlow<T>(
+internal open class PublishFlowTap<T>(
     private val upstream: Flow<T>,
     private val downstreamBufferSize: Int
-) : ConnectableFlow<T> {
+) : FlowTap<T> {
 
     private var isConnected = false
 


### PR DESCRIPTION
Closes #1.